### PR TITLE
Fix rate calculation in exchange API

### DIFF
--- a/internal/api/exchange.go
+++ b/internal/api/exchange.go
@@ -26,7 +26,7 @@ func calculateRate(interval string, intervalNum int, limit int) float64 {
 		seconds = 60
 	}
 
-	return float64(limit / seconds / intervalNum)
+	return float64(limit) / float64(seconds) / float64(intervalNum)
 }
 
 func init() {


### PR DESCRIPTION
## Summary
- correct `calculateRate` to prevent integer truncation

## Testing
- `go vet ./...` *(fails: forbidden module download)*
- `go test ./...` *(fails: forbidden module download)*

------
https://chatgpt.com/codex/tasks/task_e_6841424f09448329830881ea9f2e0ce4